### PR TITLE
Feature/queues

### DIFF
--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -35,4 +35,6 @@ RQ_HOST = 'localhost'
 RQ_PORT = 6379
 RQ_DB = 0
 RQ_PASSWORD = ''
+
+WORKERS=4
 # }}}

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -82,7 +82,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         """
         # Acknowledgment has come
         # Send a READY for each available worker
-        for i in range(0, CONF.WORKERS):
+        for i in range(0, conf.WORKERS):
             self.send_ready()
             Worker(self.request_queue,
                    self.finished_queue).start()
@@ -108,7 +108,6 @@ class JobManager(HeartbeatMixin, EMQPService):
                 except Queue.Empty:
                     break
                 else:
-                    logger.debug('Job done, sending ready')
                     self.send_ready()
 
             if not self.maybe_send_heartbeat(events):

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -17,7 +17,7 @@
 ================================
 Ensures things about jobs and spawns the actual tasks
 """
-from json import loads as serializer
+import json
 import logging
 import signal
 
@@ -31,6 +31,8 @@ from .utils.messages import send_emqp_message as sendmsg
 from .utils.timeutils import monotonic
 from .worker import MultiprocessWorker as Worker
 from eventmq.log import setup_logger
+from multiprocessing import Queue as mp_queue, Process
+import Queue
 
 logger = logging.getLogger(__name__)
 
@@ -60,25 +62,15 @@ class JobManager(HeartbeatMixin, EMQPService):
         self.name = kwargs.pop('name', generate_device_name())
         logger.info('Initializing JobManager {}...'.format(self.name))
 
-        #: Number of workers that are available to have a job executed. This
-        #: number changes as workers become busy with jobs
-        self.available_workers = 20
-
-        #: Setup worker pool
-        self.worker_pool = []
-        for i in range(self.available_workers):
-            self.worker_pool.append(Worker())
+        #: Setup worker queues
+        self.request_queue = mp_queue()
+        self.finished_queue = mp_queue()
 
         #: JobManager starts out by INFORMing the router of it's existance,
         #: then telling the router that it is READY. The reply will be the unit
         #: of work.
         # Despite the name, jobs are received on this socket
         self.outgoing = Sender(name=self.name)
-
-        #: Jobs that are running should be stored in `active_jobs`. There
-        #: should always be at most `available_workers` count of active jobs.
-        #: this point the manager should wait for a slot to free up.
-        self.active_jobs = []
 
         self.poller = Poller()
 
@@ -90,19 +82,16 @@ class JobManager(HeartbeatMixin, EMQPService):
         """
         # Acknowledgment has come
         # Send a READY for each available worker
-        for i in range(0, self.available_workers):
+        for i in range(0, CONF.WORKERS):
             self.send_ready()
+            Worker(self.request_queue,
+                   self.finished_queue).start()
 
+        while True:
             # handle any sighups by reloading config
             signal.signal(signal.SIGHUP, self.sighup_handler)
 
-        while True:
             if self.received_disconnect:
-                # self.reset()
-                # Shut down if there are no active jobs waiting
-                if len(self.active_jobs) > 0:
-                    self.prune_active_jobs()
-                    continue
                 break
 
             now = monotonic()
@@ -112,7 +101,15 @@ class JobManager(HeartbeatMixin, EMQPService):
                 msg = self.outgoing.recv_multipart()
                 self.process_message(msg)
 
-            self.prune_active_jobs()
+            # Send readys for each finished job
+            while True:
+                try:
+                    self.finished_queue.get_nowait()
+                except Queue.Empty:
+                    break
+                else:
+                    logger.debug('Job done, sending ready')
+                    self.send_ready()
 
             if not self.maybe_send_heartbeat(events):
                 break
@@ -147,15 +144,11 @@ class JobManager(HeartbeatMixin, EMQPService):
         # queue_name = msg[0]
 
         # run callable
-        payload = serializer(msg[2])
+        payload = json.loads(msg[2])
         # subcmd = payload[0]
         params = payload[1]
 
-        w = self.worker_pool.pop()
-        w.run(params)  # Spawns job w/ multiprocess
-        self.active_jobs.append(w)
-
-        self.available_workers -= 1
+        self.request_queue.put(params)
 
     def send_ready(self):
         """
@@ -170,17 +163,6 @@ class JobManager(HeartbeatMixin, EMQPService):
         in :meth:`self.process_message` as every message is counted as a
         HEARTBEAT
         """
-
-    def prune_active_jobs(self):
-        # Maintain the list of active jobs
-        for job in self.active_jobs:
-            if not job.is_alive():
-                self.active_jobs.remove(job)
-                self.worker_pool.append(job)
-                self.available_workers += 1
-
-                if not self.received_disconnect:
-                    self.send_ready()
 
     def sighup_handler(self, signum, frame):
         logger.info('Caught signal %s' % signum)

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -31,7 +31,7 @@ from .utils.messages import send_emqp_message as sendmsg
 from .utils.timeutils import monotonic
 from .worker import MultiprocessWorker as Worker
 from eventmq.log import setup_logger
-from multiprocessing import Queue as mp_queue, Process
+from multiprocessing import Queue as mp_queue
 import Queue
 
 logger = logging.getLogger(__name__)

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -62,7 +62,7 @@ class JobManager(HeartbeatMixin, EMQPService):
 
         #: Number of workers that are available to have a job executed. This
         #: number changes as workers become busy with jobs
-        self.available_workers = 4
+        self.available_workers = 20
 
         #: Setup worker pool
         self.worker_pool = []

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -42,7 +42,7 @@ class JobManager(HeartbeatMixin, EMQPService):
     The exposed portion of the worker. The job manager's main responsibility is
     to manage the resources on the server it's running.
 
-    This job manager uses tornado's eventloop.
+    This job manager uses multiprocessing Queues
     """
     SERVICE_TYPE = 'worker'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -17,7 +17,7 @@
 ================================
 Ensures things about jobs and spawns the actual tasks
 """
-import json
+from json import loads as serializer
 import logging
 import signal
 
@@ -144,7 +144,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         # queue_name = msg[0]
 
         # run callable
-        payload = json.loads(msg[2])
+        payload = serializer(msg[2])
         # subcmd = payload[0]
         params = payload[1]
 

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -20,10 +20,62 @@ Defines different short-lived workers that execute jobs
 from importlib import import_module
 import logging
 from multiprocessing import Pool
+import multiprocessing
 
 from eventmq.log import setup_logger
 
 logger = logging.getLogger(__name__)
+
+def _run(payload):
+    """
+    process a run message and execute a job
+
+    This is designed to run in a seperate process.
+    """
+    # Spawn in a new multiprocess
+    if ":" in payload["path"]:
+        _pkgsplit = payload["path"].split(':')
+        s_package = _pkgsplit[0]
+        s_cls = _pkgsplit[1]
+    else:
+        s_package = payload["path"]
+        s_cls = None
+
+    s_callable = payload["callable"]
+
+    package = import_module(s_package)
+    if s_cls:
+        cls = getattr(package, s_cls)
+
+        if "class_args" in payload:
+            class_args = payload["class_args"]
+        else:
+            class_args = ()
+
+        if "class_kwargs" in payload:
+            class_kwargs = payload["class_kwargs"]
+        else:
+            class_kwargs = {}
+
+        obj = cls(*class_args, **class_kwargs)
+        callable_ = getattr(obj, s_callable)
+    else:
+        callable_ = getattr(package, s_callable)
+
+    if "args" in payload:
+        args = payload["args"]
+    else:
+        args = ()
+
+    if "kwargs" in payload:
+        kwargs = payload["kwargs"]
+    else:
+        kwargs = {}
+
+    try:
+        callable_(*args, **kwargs)
+    except Exception as e:
+        logger.exception(e.message)
 
 
 class MultiprocessWorker(object):
@@ -37,62 +89,10 @@ class MultiprocessWorker(object):
         """
         Begins processing a job in another process
         """
-	self.process = self.pool.apply_async(self._run, (payload,))
+	self.process = self.pool.apply(_run, (payload,))
 
-    def _run(self, payload):
-        """
-        process a run message and execute a job
-
-        This is designed to run in a seperate process.
-        """
-        # Spawn in a new multiprocess
-        if ":" in payload["path"]:
-            _pkgsplit = payload["path"].split(':')
-            s_package = _pkgsplit[0]
-            s_cls = _pkgsplit[1]
-        else:
-            s_package = payload["path"]
-            s_cls = None
-
-        s_callable = payload["callable"]
-
-        package = import_module(s_package)
-        if s_cls:
-            cls = getattr(package, s_cls)
-
-            if "class_args" in payload:
-                class_args = payload["class_args"]
-            else:
-                class_args = ()
-
-            if "class_kwargs" in payload:
-                class_kwargs = payload["class_kwargs"]
-            else:
-                class_kwargs = {}
-
-            obj = cls(*class_args, **class_kwargs)
-            callable_ = getattr(obj, s_callable)
-        else:
-            callable_ = getattr(package, s_callable)
-
-        if "args" in payload:
-            args = payload["args"]
-        else:
-            args = ()
-
-        if "kwargs" in payload:
-            kwargs = payload["kwargs"]
-        else:
-            kwargs = {}
-
-        try:
-            callable_(*args, **kwargs)
-        except Exception as e:
-            logger.exception(e.message)
 
     def is_alive(self):
-	if self.process:
-            return not self.process.ready()
         return False
 
 def worker_main():

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -19,11 +19,7 @@ Defines different short-lived workers that execute jobs
 """
 from importlib import import_module
 import logging
-from multiprocessing import Pool
-import multiprocessing
-from multiprocessing import Queue, Process
-
-from eventmq.log import setup_logger
+from multiprocessing import Process
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +32,7 @@ class MultiprocessWorker(Process):
         super(MultiprocessWorker, self).__init__()
         self.input_queue = input_queue
         self.output_queue = output_queue
-        
+
     def run(self):
         """
         process a run message and execute a job

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -43,7 +43,7 @@ class MultiprocessWorker(Process):
 
         This is designed to run in a seperate process.
         """
-        # Spawn in a new multiprocess
+        # Pull the payload off the queue and run it
         for payload in iter(self.input_queue.get, None):
             if ":" in payload["path"]:
                 _pkgsplit = payload["path"].split(':')
@@ -89,4 +89,5 @@ class MultiprocessWorker(Process):
             except Exception as e:
                 logger.exception(e.message)
 
+            # Signal that we're done with this job
             self.output_queue.put('DONE')


### PR DESCRIPTION
What

Use a multiprocessing queue to talk between jobmanager and worker threads. request_queue puts payloads of jobs into the worker pool, as each worker finishes it responds to the finished_queue that sends a READY back to router freeing another job slot.

Happy side-effect is that logging just gets redirected to stdout like you'd expect so it just works.

Why

Simple and thread-safe worker pool

Tests
I put both workers in prod on this version and tested slack/dropbox