### PR TITLE
List-ify Router.queues

### DIFF
--- a/bin/emq-jobmanager
+++ b/bin/emq-jobmanager
@@ -21,12 +21,19 @@ from eventmq.jobmanager import JobManager
 from eventmq import conf
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Listen for requests')
-    parser.add_argument('--config', '-c', type=str, nargs='?',
+    parser = argparse.ArgumentParser(description='Listen for job requests and '
+                                     'manage their execution')
+    parser.add_argument('--broker-addr', '-B', type=str, nargs='?',
+                        help='manually specify the broker address to connect '
+                        'to in order to receive jobs')
+    parser.add_argument('--config', '-C', type=str, nargs='?',
                         help='manually specify the location of eventmq.conf')
     parser.add_argument('--queues', '-Q', type=str, nargs='+',
                         help='space separated list of queue names to listen '
                              'on')
+    parser.add_argument('--jobs', '-J', type=int, nargs='?',
+                        help='the max number of concurrent jobs to manage at '
+                        'a time')
 
     args = parser.parse_args()
 
@@ -39,5 +46,8 @@ if __name__ == "__main__":
     if queues:
         queues = ','.join(queues)
 
-    j = JobManager(queues=queues)
-    j.jobmanager_main()
+    broker_addr = args.broker_addr
+    concurrent_jobs = args.jobs
+
+    j = JobManager(queues=queues, concurrent_jobs=concurrent_jobs)
+    j.jobmanager_main(broker_addr=broker_addr)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ import sys
 import os
 import shlex
 
+import eventmq   # for __version__
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -52,15 +53,15 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'EventMQ'
-copyright = u'2015, eventboard.io'
-author = u'eventboard.io'
+copyright = u'2016, eventboard.io'
+author = u'EventMQ Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '0'
+version = eventmq.__version__
 # The full version, including alpha/beta/rc tags.
 release = '0'
 

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -71,7 +71,7 @@ FRAME  Value          Description
 1      eMQP/1.0       Protocol version
 2      REQUEST        command
 3      _MSGID_        A unique id for the msg
-4      _QUEUE_NAME_   the name of the queue the worker belongs to
+4      _QUEUE_NAME_   the name of the queue the request should be sent to
 5      _HEADERS_      dictionary of headers. can be an empty set
 6      _MSG_          The message to send
 ====== ============== ===========
@@ -85,7 +85,7 @@ FRAME  Value          Description
 1      eMQP/1.0       Protocol version
 2      PUBLISH        command
 3      _MSGID_        A unique id for the msg
-4      _TOPIC_NAME_   the name of the queue the worker belongs to
+4      _TOPIC_NAME_   the name of the topic this message should be published across
 5      _HEADERS_      csv list of headers
 6      _MSG_          The message to send
 ====== ============== ===========
@@ -99,7 +99,7 @@ FRAME   Value         Description
 1      eMQP/1.0       Protocol version
 2      SCHEDULE       command
 3      _MSGID_        A unique id for the msg
-4      _TOPIC_NAME_   name of queue that the job should run in
+4      _QUEUE_NAME_   name of queue that the job should run in
 5      _HEADERS_      csv list of headers for this message
 6      _MSG_          The message to send
 ====== ============== ===========
@@ -113,7 +113,7 @@ FRAME   Value         Description
 1      eMQP/1.0       Protocol version
 2      UNSCHEDULE     command
 3      _MSGID_        A unique id for the msg
-4      _TOPIC_NAME_   ignored for this command, broadcasted to all queues
+4      _QUEUE_NAME_   ignored for this command, broadcasted to all queues
 5      _HEADERS_      csv list of headers for this message
 6      _MSG_          The message to send
 ====== ============== ===========
@@ -129,7 +129,7 @@ FRAME   Value         Description
 1      eMQP/1.0       Protocol version
 2      INFORM         command
 3      _MSGID_        A unique id for the msg
-4      _QUEUE_NAME_   csv seperated names of queue the worker belongs to
+4                     Queues. Unused for scheduler
 5      scheduler      type of peer connecting
 ====== ============== ===========
 
@@ -144,7 +144,7 @@ FRAME   Value         Description
 1      eMQP/1.0       Protocol version
 2      INFORM         command
 3      _MSGID_        A unique id for the msg
-4      _QUEUE_NAME_   csv seperated names of queue the worker belongs to.
+4      _QUEUES_       csv seperated arrays containing an int and a string for weight and name. e.g. [40, 'email']
 5      worker         type of peer connecting
 ====== ============== ===========
 
@@ -203,7 +203,6 @@ Heartbeating
  * If the worker detects that the broker disconnected it SHOULD restart the conversation.
  * If the broker detects that a worker has disconnected it should stop sending it a message of any type.
  * If the scheduler detects that the broker disconnects it SHOULD restart the conversation.
- * If the broker detects that a scheduler has disconnected it should ??????????.
 
 REQUEST Headers
 ---------------

--- a/docs/settings_file.rst
+++ b/docs/settings_file.rst
@@ -15,16 +15,34 @@ Scheduler
 Job Manager
 ***********
 
+concurrent_jobs
+===============
+Default: 4
+
+This is the number of concurrent jobs the indiviudal job manager should execute
+at a time. If you are using the multiprocess or threading model this number
+becomes important as you will want to control the load on your server. If the
+load equals the number of cores on the server, processes will begin waiting for
+cpu cycles and things will begin to slow down.
+
+A safe number to choose if your jobs block a lot would be (2 * cores). If your
+jobs are cpu intensive you will want to set this number to the number of cores
+you have or (cores - 1) to leave cycles for the os and other processes. This is
+something that will have to be tuned based on the jobs that are
+running. Grouping similar jobs in named queues will help you tune this number.
+
 queues
 ======
-Default: default
+Default: (10, default)
 
-Comma seperated list of queues to process jobs for. Example:
-``queues=high,med,low,default``. The philosophy taken for this list is each job
-manager should have a single primary queue. This queue is the first in the list
-(in the case of the example ``high`` is the primary queue). Subsequent queues
-are queues that this job manager should help out with should jobs be backed up,
-and there are no primary queue jobs to take care of.
+Semi-colon seperated list of queues to process jobs for with thier
+weights. Example: ``queues=(10, data_process); (15, email)``.  With these
+weights and the ``CONCURRENT_JOBS`` setting, you should be able to tune managers
+running jobs locally pretty efficiently. If you have a larger box with a weight
+of 50 on q1 and 8 concurrent jobs and a smaller box with a weight 30 and 4
+concurrent jobs, the q1 jobs will be sent to the large box until it is no longer
+accepting jobs. At this point jobs will start to be sent to the next highest
+number until the large box is ready to accept another q1 job.
 
 .. note::
 

--- a/docs/settings_file.rst
+++ b/docs/settings_file.rst
@@ -1,0 +1,33 @@
+########
+Settings
+########
+EventMQ uses a standard INI style config file found at ``/etc/eventmq.conf``.
+
+******
+Router
+******
+
+*********
+Scheduler
+*********
+
+***********
+Job Manager
+***********
+
+queues
+======
+Default: default
+
+Comma seperated list of queues to process jobs for. Example:
+``queues=high,med,low,default``. The philosophy taken for this list is each job
+manager should have a single primary queue. This queue is the first in the list
+(in the case of the example ``high`` is the primary queue). Subsequent queues
+are queues that this job manager should help out with should jobs be backed up,
+and there are no primary queue jobs to take care of.
+
+.. note::
+
+   It is recommended that you have some workers listening for jobs on your
+   default queue so that anything that is not explicitly assigned will still be
+   run.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -1,0 +1,8 @@
+#############
+Using EventMQ
+#############
+
+.. toctree::
+   :maxdepth: 2
+
+   settings_file

--- a/etc/eventmq.docker.conf
+++ b/etc/eventmq.docker.conf
@@ -1,4 +1,10 @@
-[settings]
+[global]
+# Enable message output at different stages in the app.
+super_debug = true
+
+# Hide the heartbeat logs when super_debug is enabled. Showing them will generate a lot of messages.
+hide_heartbeat_logs = True
+
 frontend_addr=tcp://0.0.0.0:47291
 backend_addr=tcp://0.0.0.0:47290
 worker_addr=tcp://eventmq:47290
@@ -9,5 +15,6 @@ scheduler_addr=tcp://eventmq:47291
 [scheduler]
 
 [jobmanager]
-queues=one,two,three,default
 worker_addr=tcp://127.0.0.1:47290
+queues=[[50,"google"], [40,"pushes"], [10,"default"]]
+concurrent_jobs=2

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.1.10.3'
+__version__ = '0.2.0'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -1,13 +1,40 @@
-# SUPER_DEBUG basically enables more debugging logs. specifically of messages
-# at different levels in the application
-SUPER_DEBUG = True
-# Don't show HEARTBEAT message when debug logging is enabled
+# This file is part of eventmq.
+#
+# eventmq is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# eventmq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
+"""
+:mod:`conf` -- Settings Definitions
+===================================
+"""
+
+#: SUPER_DEBUG basically enables more debugging logs. Specifically the messages
+#: at different levels in the application.
+#: Default: False
+SUPER_DEBUG = False
+
+#: Don't show HEARTBEAT message when debug logging is enabled
+#: Default: True
 HIDE_HEARTBEAT_LOGS = True
 
 # When a queue name isn't specified use this queue name for the default. It
 # would be a good idea to have a handful of workers listening on this queue
 # unless you're positive that everything specifies a queue with workers.
 DEFAULT_QUEUE_NAME = 'default'
+DEFAULT_QUEUE_WEIGHT = 10
+
+# Default queues for the Job Manager to listen on. The values here should match
+# the values defined on the router.
+QUEUES = [(DEFAULT_QUEUE_WEIGHT, DEFAULT_QUEUE_NAME), ]
 
 # {{{Job Manager
 # How long should we wait before retrying to connect to a broker?
@@ -30,13 +57,14 @@ BACKEND_ADDR = 'tcp://127.0.0.1:47290'
 SCHEDULER_ADDR = 'tcp://127.0.0.1:47291'
 WORKER_ADDR = 'tcp://127.0.0.1:47290'
 
+# How many jobs should the job manager concurrently handle?
+CONCURRENT_JOBS = 4
+HWM = 10000
+
 # Redis settings
 RQ_HOST = 'localhost'
 RQ_PORT = 6379
 RQ_DB = 0
 RQ_PASSWORD = ''
-WORKERS = 4
-HWM = 10000
 
-QUEUES = '{}'.format(DEFAULT_QUEUE_NAME)
 # }}}

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -185,8 +185,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         if self.queues:
             conf.QUEUES = self.queues
 
-        self.start(addr=conf.WORKER_ADDR, queues=self.queues or \
-                   conf.QUEUES)
+        self.start(addr=conf.WORKER_ADDR, queues=self.queues or conf.QUEUES)
 
 
 def jobmanager_main():

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -18,6 +18,7 @@
 Routes messages to workers (that are in named queues).
 """
 from copy import copy
+import json  # deserialize queues in on_inform. should be refactored
 import logging
 import signal
 
@@ -29,7 +30,7 @@ from .utils.messages import (
     fwd_emqp_router_message as fwdmsg,
     parse_router_message
 )
-from .utils import zero_index_cmp
+from .utils import tuplify, zero_index_cmp
 from .utils.settings import import_settings
 from .utils.devices import generate_device_name
 from .utils.timeutils import monotonic, timestamp
@@ -76,8 +77,8 @@ class Router(HeartbeatMixin):
         #: here.
         #:
         #: **Keys**
-        #:  * ``queues``: list() of queues the worker belongs to. The highest
-        #     priority queue should come first.
+        #:  * ``queues``: list() of queue names and prioritiess the worker
+        #:    belongs to. e.g. (10, 'default')
         #:  * ``hb``: monotonic timestamp of the last received message from
         #:    worker
         #:  * ``available_slots``: int count of jobs this manager can still
@@ -246,10 +247,10 @@ class Router(HeartbeatMixin):
         queue_names = msg[0]
         client_type = msg[1]
 
-        if not queue_names:
-            queues = ('default', )
+        if not queue_names:  # Ideally, this matches some workers
+            queues = [(conf.DEFAULT_QUEUE_WEIGHT, conf.DEFAULT_QUEUE_NAME), ]
         else:
-            queues = queue_names.split(',')
+            queues = list(map(tuplify, json.loads(queue_names)))
 
         logger.info('Received INFORM request from {} (type: {})'.format(
             sender, client_type))
@@ -274,16 +275,17 @@ class Router(HeartbeatMixin):
             msgid (str): Unique identifier for this message
             msg: The actual message that was sent
         """
+        queue_names = self.workers[sender]['queues']
+
         # if there are waiting messages for the queues this worker is a member
         # of, then reply back with the oldest waiting message, otherwise just
         # add the worker to the list of available workers.
         # Note: This is only taking into account the queue the worker is
         # returning from, and not other queue_names that might have had
         # messages waiting even longer.
-        queue_names = self.workers[sender]['queues']
-
         # Assumes the highest priority queue comes first
-        for queue_name in queue_names:
+        for queue in queue_names:
+            queue_name = queue[1]
             if queue_name in self.waiting_messages.keys():
                 logger.debug('Found waiting message in the %s waiting_messages'
                              ' queue' % queue_name)
@@ -292,12 +294,13 @@ class Router(HeartbeatMixin):
                 fwdmsg(self.outgoing, sender, msg)
 
                 # It is easier to check if a key exists rather than the len of
-                # a key if it exists elsewhere, so if that was the last message
-                # remove the queue
+                # a key's value if it exists elsewhere, so if that was the last
+                # message remove the queue
                 if len(self.waiting_messages[queue_name]) == 0:
                     logger.debug('No more messages in waiting_messages queue '
                                  '%s. Removing from list...' % queue_name)
                     del self.waiting_messages[queue_name]
+
                 # the message has been forwarded so short circuit that way the
                 # manager isn't reslotted
                 return
@@ -392,17 +395,9 @@ class Router(HeartbeatMixin):
                                 conf.HEARTBEAT_TIMEOUT))
 
                 # Remove the worker from the actual queues
-                for i in range(0, len(self.workers[worker_id]['queues'])):
-                    if i == 0:
-                        priority = 10
-                    else:
-                        priority = 0
-
-                    queue = self.workers[worker_id]['queues'][i]
-
+                for queue in self.workers[worker_id]['queues']:
                     try:
-                        self.queues[queue].remove((priority, worker_id))
-                        break
+                        self.queues[queue[1]].remove((queue[0], worker_id))
                     except KeyError:
                         # This queue disappeared for some reason
                         continue
@@ -426,6 +421,10 @@ class Router(HeartbeatMixin):
             raise TypeError('type of `queue` parameter not one of (list, '
                             'tuple). got {}'.format(type(queues)))
 
+        if worker_id in self.workers:
+            logger.warning('Worker id already found in `workers`. Overwriting '
+                           'data')
+
         # Add the worker to our worker dict
         self.workers[worker_id] = {}
         self.workers[worker_id]['queues'] = tuple(queues)
@@ -433,21 +432,15 @@ class Router(HeartbeatMixin):
         self.workers[worker_id]['available_slots'] = 0
 
         # Define priorities. First element is the highest priority
-        for i in range(len(queues)):
-            if i == 0:
-                priority = 10
-            else:
-                priority = 0
+        for q in queues:
+            if q[1] not in self.queues:
+                self.queues[q[1]] = list()
 
-            if queues[i] not in self.queues:
-                self.queues[queues[i]] = EMQdeque()
+            self.queues[q[1]].append((q[0], worker_id))
+            self.queues[q[1]] = self.prioritize_queue_list(self.queues[q[1]])
 
-            self.queues[queues[i]].append((priority, worker_id))
-
-            self.queues[queues[i]] = \
-                self.prioritize_queue_list(self.queues[queues[i]])
         logger.debug('Added worker {} to the queues {}'.format(
-                     worker_id, queues))
+                 worker_id, queues))
 
     def get_available_worker(self, queue_name=conf.DEFAULT_QUEUE_NAME):
         """
@@ -480,15 +473,19 @@ class Router(HeartbeatMixin):
                 # pop the next job manager id & check if it has a worker slot
                 # if it doesn't add it to popped_workers to be added back to
                 # self.queues after the loop
-                worker = self.queues[queue_name].popleft()
+                worker = self.queues[queue_name].pop(0)
+
                 # LRU when sorted later by appending
                 popped_workers.append(worker)
+
                 if self.workers[worker[1]]['available_slots'] > 0:
                     worker_addr = worker[1]
                     break
+
             except KeyError:
-                # This should only happen if worker[1] is missing:
-                #  - available slots is pre set to 0 self.add_worker
+                # This should only happen if worker[1] is missing 1 from
+                # self.workers because:
+                #  - available slots initialized to 0 self.add_worker()
                 #  - we already checked that self.queues[queue_name] exists
                 logger.error("Worker {} not found for queue {}".format(
                     worker, queue_name))
@@ -497,14 +494,16 @@ class Router(HeartbeatMixin):
                                  worker, queue_name
                              ))
                 continue
+
             except IndexError:
                 # worker[1] should exist if it follows the (priority, id) fmt
-                logger.error("Invalid worker format in self.queues {}".format(
-                    worker
-                ))
+                logger.error("Invalid priority/worker format in self.queues "
+                             "{}".format(worker))
                 continue
+        else:
+            # No more queues to try
+            pass
 
-        # Should always evaluate to true
         if popped_workers:
             self.queues[queue_name].extend(popped_workers)
             self.queues[queue_name] = self.prioritize_queue_list(
@@ -552,12 +551,6 @@ class Router(HeartbeatMixin):
         Add a worker back to the pools for which it is a member of.
         """
         self.workers[worker_id]['available_slots'] += 1
-
-    def queue_message(self, msg):
-        """
-        Add a message to the queue for processing later
-        """
-        raise NotImplementedError()
 
     def process_client_message(self, original_msg, depth=0):
         """
@@ -691,13 +684,9 @@ class Router(HeartbeatMixin):
             IndexError - There was no 0-index element.
 
         Returns:
-            sorted :class:`EMQdeque` with largest priorites being indexed
-            smaller. E.g. ((20,'a' ), (14, 'b'), ('12', c))
+            decsending order list. E.g. ((20, 'a'), (14, 'b'), (12, 'c'))
         """
-        return EMQdeque(
-            initial=sorted(unprioritized_iterable,
-                           cmp=zero_index_cmp,
-                           reverse=True))
+        return sorted(unprioritized_iterable, cmp=zero_index_cmp, reverse=True)
 
     def sighup_handler(self, signum, frame):
         """

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -23,8 +23,6 @@ ADDR = 'inproc://pour_the_rice_in_the_thing'
 
 
 class TestCase(unittest.TestCase):
-    jm = None
-
     def test__setup(self):
         jm = jobmanager.JobManager(name='RuckusBringer')
         self.assertEqual(jm.name, 'RuckusBringer')
@@ -62,8 +60,8 @@ class TestCase(unittest.TestCase):
 
         jm._start_event_loop()
 
-        # send conf.WORKERS ready messages
-        self.assertEqual(conf.WORKERS, send_ready_mock.call_count)
+        # send int(conf.CONCURRENT_JOBS) ready messages
+        self.assertEqual(conf.CONCURRENT_JOBS, send_ready_mock.call_count)
 
         process_msg_mock.assert_called_with(
             sender_mock.return_value)
@@ -86,6 +84,7 @@ class TestCase(unittest.TestCase):
             callback=jm.worker_done,
             func=run_mock)
 
+# Other Tests
     @mock.patch('eventmq.jobmanager.JobManager.start')
     @mock.patch('eventmq.jobmanager.import_settings')
     @mock.patch('eventmq.jobmanager.Sender.rebuild')
@@ -111,7 +110,7 @@ class TestCase(unittest.TestCase):
     @mock.patch('eventmq.jobmanager.import_settings')
     @mock.patch('eventmq.jobmanager.setup_logger')
     def test_jobmanager_main(self, setup_logger_mock, import_settings_mock,
-                        start_mock):
+                             start_mock):
         jm = jobmanager.JobManager()
 
         jm.jobmanager_main()
@@ -125,7 +124,7 @@ class TestCase(unittest.TestCase):
         start_mock.assert_called_with(addr=conf.WORKER_ADDR,
                                       queues=conf.QUEUES)
 
-        jm.queues = ('derp', 'blurp')
+        jm.queues = ((10, 'derp'), (0, 'blurp'))
         jm.jobmanager_main()
 
         start_mock.assert_called_with(addr=conf.WORKER_ADDR,

--- a/eventmq/tests/test_router.py
+++ b/eventmq/tests/test_router.py
@@ -356,7 +356,6 @@ class TestCase(unittest.TestCase):
         self.assertIn((0, worker1_id), list(self.router.queues['shop']))
 
     def test_get_available_worker(self):
-        worker1_id = 'w1'
         worker2_id = 'w2'
         worker3_id = 'w3'
 
@@ -364,42 +363,35 @@ class TestCase(unittest.TestCase):
         queue2_id = 'jimjam'
 
         self.router.queues = {
-            queue1_id: EMQdeque(initial=[(10, worker1_id), (0, worker2_id)]),
-            queue2_id: EMQdeque(initial=[(10, worker2_id), (10, worker3_id)]),
+            queue1_id: EMQdeque(initial=[(10, worker3_id), (0, worker2_id)]),
+            queue2_id: EMQdeque(initial=[(10, worker2_id)]),
         }
 
         self.router.workers = {
-            worker1_id: {
-                'queues': (queue1_id,),
-                'available_slots': 0,
-            },
             worker2_id: {
                 'queues': (queue2_id, queue1_id),
                 'available_slots': 1,
             },
             worker3_id: {
-                'queues': (queue2_id,),
+                'queues': (queue1_id,),
                 'available_slots': 1,
             },
         }
 
         # worker1 has no available slots.
-        check1 = self.router.get_available_worker(queue_name=queue1_id)
+        check1 = self.router.get_available_worker(queue_name=queue2_id)
         self.assertEqual(worker2_id, check1)
-        self.assertEqual(self.router.workers[worker2_id]['available_slots'], 0)
+        self.assertEqual(self.router.workers[worker2_id]['available_slots'], 1)
 
-        # worker2 is busy processing the last job
-        check2 = self.router.get_available_worker(queue_name=queue2_id)
+        check2 = self.router.get_available_worker(queue_name=queue1_id)
         self.assertEqual(worker3_id, check2)
-        self.assertEqual(self.router.workers[worker3_id]['available_slots'], 0)
+        self.assertEqual(self.router.workers[worker3_id]['available_slots'], 1)
 
-        # worker1 and worker2 return
-        self.router.workers[worker2_id]['available_slots'] = 1
-        self.router.workers[worker1_id]['available_slots'] = 1
+        self.router.workers[worker3_id]['available_slots'] = 0
 
         check3 = self.router.get_available_worker(queue_name=queue1_id)
-        self.assertEqual(worker1_id, check3)
-        self.assertEqual(self.router.workers[worker1_id]['available_slots'], 0)
+        self.assertEqual(worker2_id, check3)
+        self.assertEqual(self.router.workers[worker2_id]['available_slots'], 1)
 
     def test_requeue_worker(self):
         worker_id = 'w1'

--- a/eventmq/utils/__init__.py
+++ b/eventmq/utils/__init__.py
@@ -46,3 +46,15 @@ def zero_index_cmp(a, b):
     when sorting the values in :attr:`router.Router.queues`.
     """
     return cmp(a[0], b[0])
+
+
+def tuplify(v):
+    """
+    Recursively convert lists to tuples.
+
+    Args:
+        v (object): any value of interest
+    """
+    if isinstance(v, list):
+        return tuple(map(tuplify, v))
+    return v

--- a/eventmq/utils/messages.py
+++ b/eventmq/utils/messages.py
@@ -164,9 +164,7 @@ def fwd_emqp_router_message(socket, recipient_id, payload):
     try:
         socket.zsocket.send_multipart(payload)
     except zmq.error.ZMQError as e:
-        logger.critical(dir(e))
-        logger.critical(e.errno)
-        if e.errno == 113:
+        if e.errno == 113 or e.errno == 65:
             e.message = e.message + " {}".format(recipient_id)
             raise exceptions.PeerGoneAwayError(e)
         else:

--- a/eventmq/utils/settings.py
+++ b/eventmq/utils/settings.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 
+from . import tuplify
 from .. import conf
 
 
@@ -71,15 +72,3 @@ def import_settings(section='global'):
     else:
         logger.warning('Config file at {} not found. Continuing with '
                        'defaults.'.format(conf.CONFIG_FILE))
-
-
-def tuplify(v):
-    """
-    Recursively convert lists to tuples.
-
-    Args:
-        v (object): any value of interest
-    """
-    if isinstance(v, list):
-        return tuple(map(tuplify, v))
-    return v

--- a/eventmq/utils/settings.py
+++ b/eventmq/utils/settings.py
@@ -16,27 +16,70 @@
 :mod:`settings` -- Settings Utilities
 =====================================
 """
-import os
 import ConfigParser
-from .. import conf
+import json
 import logging
+import os
+
+from .. import conf
+
 
 logger = logging.getLogger(__name__)
 
 
-def import_settings(section='settings'):
+def import_settings(section='global'):
     """
     Import settings and apply to configuration globals
-    """
 
+    Args:
+       section (str): Name of the INI section to import
+    """
     config = ConfigParser.ConfigParser()
 
     if os.path.exists(conf.CONFIG_FILE):
         config.read(conf.CONFIG_FILE)
+
+        if not config.has_section(section):
+            logger.warning(
+                'Tried to read nonexistent section {}'.format(section))
+            return
+
         for name, value in config.items(section):
             if hasattr(conf, name.upper()):
-                t = type(getattr(conf, name.upper()))
-                setattr(conf, name.upper(), t(value))
-                logger.debug("Setting conf.%s to %s" % (name, value))
+                default_value = getattr(conf, name.upper())
+                t = type(default_value)
+                if isinstance(default_value, (list, tuple)):
+                    value = t(json.loads(value))
+                    # json.loads coverts all arrays to lists, but if the first
+                    # element in the default is a tuple (like in QUEUES) then
+                    # convert those elements, otherwise whatever it's type is
+                    # correct
+                    if isinstance(default_value[0], tuple):
+                        setattr(conf, name.upper(),
+                                t(map(tuplify, value)))
+                    else:
+                        setattr(conf, name.upper(), t(value))
+                elif isinstance(default_value, bool):
+                    setattr(conf, name.upper(),
+                            True if 't' in value.lower() else False)
+                else:
+                    setattr(conf, name.upper(), t(value))
+                logger.debug("Setting conf.{} to {}".format(
+                    name.upper(), getattr(conf, name.upper())))
             else:
                 logger.warning('Tried to set invalid setting: %s' % name)
+    else:
+        logger.warning('Config file at {} not found. Continuing with '
+                       'defaults.'.format(conf.CONFIG_FILE))
+
+
+def tuplify(v):
+    """
+    Recursively convert lists to tuples.
+
+    Args:
+        v (object): any value of interest
+    """
+    if isinstance(v, list):
+        return tuple(map(tuplify, v))
+    return v

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -20,7 +20,7 @@ Defines different short-lived workers that execute jobs
 from importlib import import_module
 import logging
 
-logger = logging.getLogger('*')
+logger = logging.getLogger(__name__)
 
 
 def run(payload):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eventmq',
-    version='0.2.0',
+    version='0.2.1',
     description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==14.6.0',

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup, find_packages
 
 setup(
     name='eventmq',
-    version='0.1.10.3',
-    description='EventMQ messaging system based off ZeroMQ',
+    version='0.2.0',
+    description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==14.6.0',
                       'six==1.10.0',


### PR DESCRIPTION
- Rename `WORKERS` setting to `CONCURRENT_JOBS` for more clarity. Added this
  setting to the command line options, the ini .conf & default settings conf.py
  files.
- Added support for JSON style arrays in INI config.
- Added support for weighted named queues. The style for the setting is
  [[weight, "name"], [weight, "name"]]. Configured in both the INI and command
  line for job manager. Added documentation.
- Updated the spec for the INFORM message. Weights are sent with the queue
  names. If there are no weights specified they will be given the default value
  of 0.
- updated Router.queues to a list from a deque so that it can be sorted
  by priority more easily.