### PR TITLE
Fix overwite of self.queues before conf.QUEUES is set

### DIFF
--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -73,8 +73,6 @@ class JobManager(HeartbeatMixin, EMQPService):
 
         #: List of queues that this job manager is listening on
         self.queues = kwargs.pop('queues', None)
-        if self.queues is None:
-            self.queues = conf.QUEUES
 
         if not kwargs.pop('skip_signal', False):
             # handle any sighups by reloading config


### PR DESCRIPTION
conf.QUEUES is always whatever is in conf.py as the default in __init__ here, so we were always overwriting self.queues with that value.