### PR TITLE
MAN-1364 - Add "start_immediately" header for scheduled jobs

### DIFF
--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -204,16 +204,17 @@ Heartbeating
  * If the broker detects that a worker has disconnected it should stop sending it a message of any type.
  * If the scheduler detects that the broker disconnects it SHOULD restart the conversation.
 
-REQUEST Headers
+Headers
 ---------------
 Headers MUST be 0 to many comma seperated values inserted into the header field. If there are no headers required, send an empty string MUST be sent where headers are required.
 
 Below is a table which defines and describes the headers.
 
-=============== ======= ======= ======= ===========
-Header          REQUEST PUBLISH Default Description
-=============== ======= ======= ======= ===========
-reply-requested X               False   Once the job is finished, send a reply back with information from the job. If there is no information reply with a True value.
-retry-count:#   X               0       Retry a failed job this many times before accepting defeat.
-guarantee       X               False   Ensure the job completes by letting someone else worry about a success reply.
-=============== ======= ======= ======= ===========
+================= ======= ======= ======== ======= ===========
+Header            REQUEST PUBLISH SCHEDULE Default Description
+================= ======= ======= ======== ======= ===========
+reply-requested   X                        False   Once the job is finished, send a reply back with information from the job. If there is no information reply with a True value.
+retry-count:#     X                        0       Retry a failed job this many times before accepting defeat.
+guarantee         X                        False   Ensure the job completes by letting someone else worry about a success reply.
+nohaste                           X        False   When scheduling a job, set this to True if you don't want the job to run immediately as it's scheduled.  Instead, it will run for the first time when the interval has elapsed.
+================= ======= ======= ======== ======= ===========

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -161,9 +161,9 @@ class JobManager(HeartbeatMixin, EMQPService):
         params = payload[1]
 
         if 'reply-requested' in headers:
-           callback = self.worker_done_with_reply
+            callback = self.worker_done_with_reply
         else:
-           callback = self.worker_done
+            callback = self.worker_done
 
         # kick off the job asynchronously with an appropiate callback
         self.workers.apply_async(func=worker.run,
@@ -185,7 +185,7 @@ class JobManager(HeartbeatMixin, EMQPService):
         sendmsg(self.outgoing, 'READY')
 
     def send_reply(self, res):
-         """
+        """
          Sends an REPLY response
 
          Args:
@@ -193,12 +193,10 @@ class JobManager(HeartbeatMixin, EMQPService):
              recipient (str): The recipient id for the ack
              msgid: The unique id that we are acknowledging
          """
-         msgid = res[0]
-
-         reply = res[1]
-
-         reply = serializer(reply)
-         sendmsg(self.outgoing, 'REPLY', [reply, msgid])
+        msgid = res[0]
+        reply = res[1]
+        reply = serializer(reply)
+        sendmsg(self.outgoing, 'REPLY', [reply, msgid])
 
     def on_heartbeat(self, msgid, message):
         """

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -354,7 +354,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
         except Exception as e:
             logger.warning(str(e))
 
-        if 'dont_start_immediately' not in headers:
+        if 'nohaste' not in headers:
             self.send_request(message[3], queue=queue)
 
     def on_heartbeat(self, msgid, message):

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -17,7 +17,6 @@
 =============================
 Handles cron and other scheduled tasks
 """
-import sys
 import json
 import logging
 import redis
@@ -298,6 +297,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
         logger.info("Received new SCHEDULE request: {}".format(message))
 
         queue = message[0]
+        headers = message[1]
         interval = int(message[2])
         cron = str(message[4])
 
@@ -354,7 +354,8 @@ class Scheduler(HeartbeatMixin, EMQPService):
         except Exception as e:
             logger.warning(str(e))
 
-        self.send_request(message[3], queue=queue)
+        if 'dont_start_immediately' not in headers:
+            self.send_request(message[3], queue=queue)
 
     def on_heartbeat(self, msgid, message):
         """


### PR DESCRIPTION
What
===

1.  Add the `start_immediately` option (header) for scheduling jobs.
This will allow you to schedule a job, and either have it run as it's
scheduled, or wait until the interval has elapsed.

Why
===

1.  We need it for the debounce decorator, among other things

Tests
=====

I tried it manually