### PR TITLE
Terminate zmq.Context in child processes

### DIFF
--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -92,10 +92,12 @@ class JobManager(HeartbeatMixin, EMQPService):
     @property
     def workers(self):
         if not hasattr(self, '_workers'):
-            self._workers = Pool(processes=conf.CONCURRENT_JOBS)
+            self._workers = Pool(processes=conf.CONCURRENT_JOBS,
+                                 initializer=mp_init)
         elif self._workers._processes != conf.CONCURRENT_JOBS:
             self._workers.close()
-            self._workers = Pool(processes=conf.CONCURRENT_JOBS)
+            self._workers = Pool(processes=conf.CONCURRENT_JOBS,
+                                 initializer=mp_init)
 
         return self._workers
 
@@ -248,3 +250,14 @@ class JobManager(HeartbeatMixin, EMQPService):
 def jobmanager_main():
     j = JobManager()
     j.jobmanager_main()
+
+
+def mp_init():
+    """
+    The instance of Context is copied when python multiprocessing fork()s the
+    worker processes, so we need to terminate that Context so a new one can be
+    rebuilt. Without doing this, messages sent from functions in those child
+    processes will never be delivered.
+    """
+    import zmq
+    zmq.Context.instance().term()


### PR DESCRIPTION
- This fixes a bug that occurs when a function attempts to send a
  message from within the job. multiprocessing uses `fork()` which copies
  the main process and assigns it a new PID. When this happens the
  context breaks. We need to remove the broken context so a new
  context is created.