### PR TITLE
Make calls more explicit

### DIFF
--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -19,7 +19,7 @@ class IgnoreJSONEncoder(json.JSONEncoder):
 
 
 def run_function(path, callable_name,
-                 class_args=(), class_kwargs=None, *args, **kwargs):
+                 class_args=(), class_kwargs=None, args=(), kwargs=None):
     """Constructs a callable from `path` and `callable_name` and calls it.
 
     Args:
@@ -36,6 +36,18 @@ def run_function(path, callable_name,
         object: Whatever is returned by calling the callable will be returned
             from this function.
     """
+    if not class_args:
+        class_args = ()
+
+    if not class_kwargs:
+        class_kwargs = {}
+
+    if not args:
+        args = ()
+
+    if not kwargs:
+        kwargs = {}
+
     try:
         callable_ = callable_from_path(
             path, callable_name, *class_args, **class_kwargs)

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -42,7 +42,12 @@ def run(payload, msgid):
 
     try:
         r = run_function(
-            path, callable_name, class_args, class_kwargs, *args, **kwargs)
+            path=path,
+            callable_name=callable_name,
+            class_args=class_args or (),
+            class_kwargs=class_kwargs or {},
+            args=args or (),
+            kwargs=kwargs or {})
         return (msgid, r)
     except Exception as e:
         logger.exception(e)


### PR DESCRIPTION
I was in *args **kwargs hell.  It was kwargseption.  This fixes it.