### PR TITLE
fix typo in unschedule wrapper

### DIFF
--- a/bin/send_msg
+++ b/bin/send_msg
@@ -3,22 +3,34 @@
 Usage: ./send_msg <ipaddresss> <command> <frame w/ values space separated>
 """
 import sys
+import zmq
 
 from eventmq.sender import Sender
 from eventmq.client.messages import send_request
 
-
 if __name__ == "__main__":
-    s = Sender()
-    s.connect(sys.argv[1])
+    for i in xrange(1):
+        s = Sender()
+        poller = zmq.Poller()
 
-    msg = ['run', {
-           'path': 'path.to.some.module:Class',
-           'callable': 'do_thing',
-           'class_args': ('blurp',),
-           'class_kwargs': {'kwarg1': True},
-           'args': ('arg1', 'arg2'),
-           'kwargs': {'kwarg1': 'something'}
-           }]
+        poller.register(s.zsocket, flags=zmq.POLLIN)
 
-    send_request(s, msg, guarantee=True, reply_requested=True)
+        s.connect(sys.argv[1])
+
+        msg = ['run', {
+            'path': 'path.to.some.module:Class',
+            'callable': 'do_thing',
+            'class_args': ('blurp',),
+            'class_kwargs': {'kwarg1': True},
+            'args': ('arg1', 'arg2'),
+            'kwargs': {'kwarg1': 'something'}
+            }]
+
+        send_request(s, msg, guarantee=True, reply_requested=True)
+        print zmq.POLLOUT
+        events = dict(poller.poll(500))
+        print events
+        if events[s.zsocket] == zmq.POLLIN:
+            msg = s.recv_multipart()
+
+            print msg

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -59,6 +59,8 @@ BACKEND_ADDR = 'tcp://127.0.0.1:47290'
 SCHEDULER_ADDR = 'tcp://127.0.0.1:47291'
 # Where the worker should connect
 WORKER_ADDR = 'tcp://127.0.0.1:47290'
+WORKER_ADDR_DEFAULT = 'tcp://127.0.0.1:47290'
+WORKER_ADDR_FAILOVER = 'tcp://127.0.0.1:47290'
 # Used to monitor and manage the devices
 ADMINISTRATIVE_ADDR = 'tcp://127.0.0.1:47293'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -126,6 +126,12 @@ class JobManager(HeartbeatMixin, EMQPService):
             # Note: `maybe_send_heartbeat` is mocked by the tests to return
             #       False, so it should stay at the bottom of the loop.
             if not self.maybe_send_heartbeat(events):
+                # Toggle default and failover worker_addr
+                if (conf.WORKER_ADDR == conf.WORKER_ADDR_DEFAULT):
+                    conf.WORKER_ADDR = conf.WORKER_ADDR_FAILOVER
+                else:
+                    conf.WORKER_ADDR = conf.WORKER_ADDR_DEFAULT
+
                 break
 
     def on_request(self, msgid, msg):

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -280,7 +280,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
         logger.info("Received new UNSCHEDULE request: {}".format(message))
 
         # TODO: Notify router whether or not this succeeds
-        self.unschedule_job(schedule_hash)
+        self.unschedule_job(message)
 
     def unschedule_job(self, message):
         """


### PR DESCRIPTION
This is already live so it doesn't crash continuously, should merge it in and get rid of the local change on that machine.

Adding broker failover support to this PR