### PR TITLE
Send noblock

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.2.6.3'
+__version__ = '0.2.6.4'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/utils/classes.py
+++ b/eventmq/utils/classes.py
@@ -546,6 +546,20 @@ class EMQdeque(object):
         """
         return self._queue.popleft()
 
+    def peek(self):
+        """
+        Returns:
+            object: the last (right-most) element of the deque
+        """
+        return self._queue[-1]
+
+    def peekleft(self):
+        """
+        Returns:
+            object: the first (left-most) element of the deque
+        """
+        return self._queue[0]
+
     def appendleft(self, item):
         """
         Append item to the left this deque if the deque isn't full.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eventmq',
-    version='0.2.6.3',
+    version='0.2.6.4',
     description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
What:

Adds the flag zmq.NOBLOCK to .send so we won't block in case the connection dies, and will now cause a PeerGoneAway Exception, which in most cases causes a retry already.  I added exception handling in the case of queued messages being sent in `on_ready` and only pop the message out of the waiting_messages queue if we don't have a PeerGoneAway exception thrown.

Also added peek/peekleft functions the EMQDeque for convenience.