### PR TITLE
Make "defer_job" and "schedule" accept string callable

### DIFF
--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -174,7 +174,7 @@ def defer_job(
     if wrapper and callable(wrapper):
         # Prepend the original path and callable name to args
         args = (path, callable_name, args)
-        path, callable_name = build_module_path(wrapper)
+        path, callable_name = path_from_callable(wrapper)
     elif wrapper:
         logger.error('Encountered non-callable wrapper: {}'.format(wrapper))
         return

--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -21,7 +21,7 @@ from json import dumps as serialize
 
 from .. import conf
 from ..utils.messages import send_emqp_message
-from ..utils.functions import path_from_callable
+from ..utils.functions import name_from_callable, split_callable_name
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ def schedule(socket, func, interval_secs=None, args=(), kwargs=None,
 
     Args:
         socket (socket): eventmq socket to use for sending the message
-        func (callable): the callable to be scheduled on a worker
+        func (callable): the callable (or string path to calable) to be
+            scheduled on a worker
         minutes (int): minutes to wait in between executions
         args (list): list of *args to pass to the callable
         interval_secs (int): Run job every interval_secs or None if using cron
@@ -74,26 +75,24 @@ def schedule(socket, func, interval_secs=None, args=(), kwargs=None,
                      'but not both (or neither)')
         return
 
-    if callable(func):
-        path, callable_name = path_from_callable(func)
+    if func and isinstance(func, basestring):
+        if '.' not in func:
+            logger.error('Invalid callable string passed, '
+                         'absolute path required: "{}"'.format(func))
+            return
+        path, callable_name = split_callable_name(func)
+    elif callable(func):
+        callable_name = name_from_callable(func)
+        path, callable_name = split_callable_name(callable_name)
     else:
         logger.error('Encountered non-callable func: {}'.format(func))
         return
 
-    if not callable_name:
-        logger.error('Encountered callable with no name in {}'.format(
-            func.__module__
-        ))
-        return
-
-    if not path:
-        logger.error('Encountered callable with no __module__ path {}'.format(
-            func.__name__
-        ))
+    if not callable_name or not path:
+        logger.error('Encountered invalid callable, will not proceed.')
         return
 
     # TODO: convert all the times to seconds for the clock
-
     msg = ['run', {
         'callable': callable_name,
         'path': path,
@@ -128,7 +127,8 @@ def defer_job(
 
     Args:
         socket (socket): eventmq socket to use for sending the message
-        func (callable): the callable to be deferred to a worker
+        func (callable or str): the callable (or string path to callable) to be
+            deferred to a worker
         wrapper (callable): optional wrapper for the call to func to be
              wrapped with
         args (list): list of *args for the callable
@@ -165,8 +165,15 @@ def defer_job(
     if not kwargs:
         kwargs = {}
 
-    if callable(func):
-        path, callable_name = path_from_callable(func)
+    if func and isinstance(func, basestring):
+        if '.' not in func:
+            logger.error('Invalid callable string passed, '
+                         'absolute path required: "{}"'.format(func))
+            return
+        path, callable_name = split_callable_name(callable_name)
+    elif callable(func):
+        callable_name = name_from_callable(func)
+        path, callable_name = split_callable_name(callable_name)
     else:
         logger.error('Encountered non-callable func: {}'.format(func))
         return
@@ -174,20 +181,14 @@ def defer_job(
     if wrapper and callable(wrapper):
         # Prepend the original path and callable name to args
         args = (path, callable_name, args)
-        path, callable_name = path_from_callable(wrapper)
+        callable_name = name_from_callable(wrapper)
+        path, callable_name = split_callable_name(callable_name)
     elif wrapper:
         logger.error('Encountered non-callable wrapper: {}'.format(wrapper))
         return
 
-    # Check for and log errors
-    if not callable_name:
-        logger.error('Encountered callable with no name in {}'.
-                     format(func.__module__))
-        return
-
-    if not path:
-        logger.error('Encountered callable with no __module__ path {}'.
-                     format(func.__name__))
+    if not callable_name or not path:
+        logger.error('Encountered invalid callable, will not proceed.')
         return
 
     msg = ['run', {

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -41,7 +41,7 @@ from eventmq.log import setup_logger
 
 logger = logging.getLogger(__name__)
 CRON_CALLER_ID = -1
-INFINITE_RUN_COUNT=-1
+INFINITE_RUN_COUNT = -1
 
 
 class Scheduler(HeartbeatMixin, EMQPService):

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -201,8 +201,8 @@ class Scheduler(HeartbeatMixin, EMQPService):
                                 logger.warning("Couldn't contact redis server")
                             except Exception as e:
                                 logger.warning(
-                                    'Unable to update key in redis server: {}'\
-                                    .format(e.message))
+                                    'Unable to update key in redis '
+                                    'server: {}'.format(e.message))
                     else:
                         # Scheduled job is in running infinitely
                         # Send job and update next schedule time
@@ -210,15 +210,15 @@ class Scheduler(HeartbeatMixin, EMQPService):
                         v[0] = next(v[2])
                         # Persist changes to redis
                         try:
-                            self.redis_server.set(self.schedule_hash(v),
-                                                    serialize(v))
+                            self.redis_server.set(
+                                self.schedule_hash(v), serialize(v))
                             self.redis_server.save()
                         except redis.ConnectionError:
                             logger.warning("Couldn't contact redis server")
                         except Exception as e:
                             logger.warning(
-                                'Unable to update key in redis server: {}'\
-                                .format(e.message))
+                                'Unable to update key in redis '
+                                'server: {}'.format(e.message))
 
             for job in cancel_jobs:
                 message = self.interval_jobs[k][1]

--- a/eventmq/tests/test_client_messages.py
+++ b/eventmq/tests/test_client_messages.py
@@ -23,12 +23,12 @@ from ..client import messages
 
 class TestClass(object):
     """
-    class to use in the path_from_callable test
+    class to use in the name_from_callable test
     """
     def mymethod(self):
         """
         this method is used as the callable in
-        :meth:`TestCase.test_path_from_callable`
+        :meth:`TestCase.test_name_from_callable`
         """
         return True
 
@@ -76,7 +76,7 @@ class TestCase(unittest.TestCase):
                                        queue='test_queue')
 
         with LogCapture() as log_checker:
-            # don't blow up on a non-callable
+            # don't blow up on an invalid callable path
             messages.defer_job(socket, 'non-callable')
 
             # don't blow up on some random nameless func
@@ -97,35 +97,38 @@ class TestCase(unittest.TestCase):
             log_checker.check(
                 ('eventmq.client.messages',
                  'ERROR',
-                 'Encountered non-callable func: non-callable'),
-                ('eventmq.client.messages',
-                 'ERROR',
-                 'Encountered callable with no name in '
-                 'eventmq.tests.test_client_messages'),
-                ('eventmq.client.messages',
-                 'ERROR',
-                 'Encountered callable with no __module__ path nameless_func'),
+                 'Invalid callable string passed, absolute path required: "non-callable"'),  # noqa
                 ('eventmq.utils.functions',
                  'ERROR',
-                 'Encountered unknown callable ({}) type instanceobject'.
-                 format(callable_obj)),
+                 'Encountered callable with no name in eventmq.tests.test_client_messages'),  # noqa
                 ('eventmq.client.messages',
                  'ERROR',
-                 'Encountered callable with no name in '
-                 'eventmq.tests.test_client_messages'),
+                 'Encountered invalid callable, will not proceed.'),
+                ('eventmq.utils.functions',
+                 'ERROR',
+                 'Encountered callable with no __module__ path nameless_func'),
+                ('eventmq.client.messages',
+                 'ERROR',
+                 'Encountered invalid callable, will not proceed.'),
+                ('eventmq.utils.functions',
+                 'ERROR',
+                 'Encountered unknown callable ({}) type instanceobject'.format(callable_obj)),  # noqa
+                ('eventmq.client.messages',
+                 'ERROR',
+                 'Encountered invalid callable, will not proceed.'),
             )
 
-    def test_path_from_callable(self):
+    def test_name_from_callable(self):
         import mimetools
-        funcpath = messages.path_from_callable(mimetools.choose_boundary)
+        funcpath = messages.name_from_callable(mimetools.choose_boundary)
 
         t = TestClass()
-        methpath = messages.path_from_callable(t.mymethod)
+        methpath = messages.name_from_callable(t.mymethod)
 
-        self.assertEqual(funcpath, ('mimetools', 'choose_boundary'))
+        self.assertEqual(funcpath, 'mimetools.choose_boundary')
         self.assertEqual(
             methpath,
-            ('eventmq.tests.test_client_messages:TestClass', 'mymethod'))
+            'eventmq.tests.test_client_messages:TestClass.mymethod')
 
     @mock.patch('eventmq.client.messages.send_schedule_request')
     def test_schedule(self, send_schedule_req_mock):
@@ -166,7 +169,7 @@ class TestCase(unittest.TestCase):
             unschedule=False)  # default arg
 
         with LogCapture() as log_checker:
-            # don't blow up on a non-callable
+            # don't blow up on an invalid callable path
             messages.schedule(socket, 'non-callable',
                               class_args=(123,),
                               interval_secs=10)
@@ -202,30 +205,31 @@ class TestCase(unittest.TestCase):
             log_checker.check(
                 ('eventmq.client.messages',
                  'ERROR',
-                 'Encountered non-callable func: non-callable'),
-                ('eventmq.client.messages',
-                 'ERROR',
-                 'Encountered callable with no name in '
-                 'eventmq.tests.test_client_messages'),
-                ('eventmq.client.messages',
-                 'ERROR',
-                 'Encountered callable with no __module__ path nameless_func'),
+                 'Invalid callable string passed, absolute path required: "non-callable"'),  # noqa
                 ('eventmq.utils.functions',
                  'ERROR',
-                 'Encountered unknown callable ({}) type instanceobject'.
-                 format(callable_obj)),
+                 'Encountered callable with no name in eventmq.tests.test_client_messages'),  # noqa
                 ('eventmq.client.messages',
                  'ERROR',
-                 'Encountered callable with no name in '
-                 'eventmq.tests.test_client_messages'),
+                 'Encountered invalid callable, will not proceed.'),
+                ('eventmq.utils.functions',
+                 'ERROR',
+                 'Encountered callable with no __module__ path nameless_func'),
                 ('eventmq.client.messages',
                  'ERROR',
-                 'First `class_args` argument must be caller_id for '
-                 'scheduling interval jobs'),
+                 'Encountered invalid callable, will not proceed.'),
+                ('eventmq.utils.functions',
+                 'ERROR',
+                 'Encountered unknown callable ({}) type instanceobject'.format(callable_obj)),  # noqa
                 ('eventmq.client.messages',
                  'ERROR',
-                 'You must sepcify either `interval_secs` or `cron`, but not '
-                 'both (or neither)'),
+                 'Encountered invalid callable, will not proceed.'),
+                ('eventmq.client.messages',
+                 'ERROR',
+                 'First `class_args` argument must be caller_id for scheduling interval jobs'),  # noqa
+                ('eventmq.client.messages',
+                 'ERROR',
+                 'You must sepcify either `interval_secs` or `cron`, but not both (or neither)'),  # noqa
             )
 
     @mock.patch('eventmq.client.messages.send_emqp_message')

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -18,11 +18,13 @@ class IgnoreJSONEncoder(json.JSONEncoder):
             return None
 
 
-def run_function(path, callable_name,
+def run_function(callable_name,
                  class_args=(), class_kwargs=None, args=(), kwargs=None):
     """Constructs a callable from `path` and `callable_name` and calls it.
 
     Args:
+        callable_name (str): The name and path of the function you wish to run,
+            eg ``eventmq.utils.functions.run_function``.
         class_args (list): If the callable is a class method, these args will
             be used to initialize the class.
         class_kwargs (dict): If the callable is a class method, these kwargs
@@ -49,11 +51,11 @@ def run_function(path, callable_name,
         kwargs = {}
 
     try:
-        callable_ = callable_from_path(
-            path, callable_name, *class_args, **class_kwargs)
+        callable_ = callable_from_name(
+            callable_name, *class_args, **class_kwargs)
     except CallableFromPathError as e:
         logger.exception('Error importing callable {}.{}: {}'.format(
-            path, callable_name, str(e)))
+            callable_name, str(e)))
         return
 
     return callable_(*args, **kwargs)
@@ -70,7 +72,7 @@ def arguments_hash(*args, **kwargs):
     return hashlib.sha1(data).hexdigest()
 
 
-def path_from_callable(func):
+def name_from_callable(func):
     """
     Builds the module path in string format for a callable.
 
@@ -83,8 +85,9 @@ def path_from_callable(func):
         func (callable): The function or method to build the path for
 
     Returns:
-        list: (import path (w/ class seperated by a ':'), callable name) or
-            (None, None) on error.
+        str: The callable path and name, eg
+            ``"eventmq.utils.functions.name_from_callable"`` would be returned
+            if you called this function on itself.
     """
     callable_name = None
 
@@ -108,23 +111,40 @@ def path_from_callable(func):
             func,
             func_type
         ))
+        return None
+
+    return '{}.{}'.format(path, callable_name)
+
+
+def split_callable_name(callable_name):
+    """Split a callable name into it's path and name components.
+
+    Args:
+        callable_name (str): The callable name, with path, eg,
+            ``eventmq.utils.functions.callable_from_name``.
+
+    Returns:
+        (str, str): The path and callable name, or None, None if a path cannot
+            be found.
+    """
+    if not callable_name or '.' not in callable_name:
         return None, None
 
-    return path, callable_name
+    elements = callable_name.split('.')
+    path = '.'.join(elements[:-1])
+    return path, elements[-1]
 
 
-def callable_from_path(path, callable_name, *args, **kwargs):
+def callable_from_name(callable_name, *args, **kwargs):
     """Build a callable from a path and callable_name.
 
-    This function is the opposite of `path_from_callable`.  It takes what is
+    This function is the opposite of `name_from_callable`.  It takes what is
     returned from `build_module_name` and converts it back to the original
     caller.
 
     Args:
-        path (str): The module path of the callable.  This is the first
-            position in the tuple returned from `path_from_callable`.
-        callable_name (str): The name of the function.  This is the second
-            position of the tuple returned from `path_from_callable`.
+        callable_name (str): The name (and path) of the function, eg,
+            ``eventmq.utils.functions.callable_from_name``.
         *args (list): if `callable_name` is a method on a class, these
             arguments will be passed to the constructor when instantiating the
             class.
@@ -135,6 +155,7 @@ def callable_from_path(path, callable_name, *args, **kwargs):
     Returns:
         function: The callable
     """
+    path, callable_name = split_callable_name(callable_name)
     if ':' in path:
         _pksplit = path.split(':')
         s_package = _pksplit[0]

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -95,10 +95,16 @@ def name_from_callable(func):
     # Methods also have the func_name property
     if inspect.ismethod(func):
         path = ("{}:{}".format(func.__module__, func.im_class.__name__))
-        callable_name = func.func_name
+        try:
+            callable_name = func.func_name
+        except AttributeError:
+            callable_name = func.__name__
     elif inspect.isfunction(func):
         path = func.__module__
-        callable_name = func.func_name
+        try:
+            callable_name = func.func_name
+        except AttributeError:
+            callable_name = func.__name__
     else:
         # We should account for another callable type so log information
         # about it
@@ -111,6 +117,21 @@ def name_from_callable(func):
             func,
             func_type
         ))
+        return None
+
+    if not callable_name:
+        logger.error(
+            'Encountered callable with no name in {}'.format(func.__module__))
+        return None
+
+    if not path:
+        try:
+            func_name = func.func_name
+        except AttributeError:
+            func_name = func.__name__
+        logger.error(
+            'Encountered callable with no __module__ path {}'.format(
+                func_name))
         return None
 
     return '{}.{}'.format(path, callable_name)

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -42,8 +42,7 @@ def run(payload, msgid):
 
     try:
         r = run_function(
-            path=path,
-            callable_name=callable_name,
+            callable_name='{}.{}'.format(path, callable_name),
             class_args=class_args or (),
             class_kwargs=class_kwargs or {},
             args=args or (),


### PR DESCRIPTION
1.  Refactor `path_from_callable` and `callable_from_path` to return and accept
a single argument for more consistency.
2.  Rename `path_from_callable` and `callable_from_path` to match the way they
function better.
3.  Make it so that when you pass a string for the `func` argument on both
`schedule` and `defer_job`, it will use that as a string path to the callable.
