### PR TITLE
add timeout support, move job_latencies start to include queue times

### DIFF
--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -227,6 +227,7 @@ Header            REQUEST PUBLISH SCHEDULE Default Description
 ================= ======= ======= ======== ======= ===========
 reply-requested   X                        False   Once the job is finished, send a reply back with information from the job. If there is no information reply with a True value.
 retry-count:#     X                        0       Retry a failed job this many times before accepting defeat.
+timeout:#         X                        0       Kill the job after X seconds, defaults to never timing out (0)
 guarantee         X                        False   Ensure the job completes by letting someone else worry about a success reply.
 nohaste                           X        False   When scheduling a job, set this to True if you don't want the job to run immediately as it's scheduled.  Instead, it will run for the first time when the interval has elapsed.
 ================= ======= ======= ======== ======= ===========

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -30,6 +30,7 @@ from .utils.classes import EMQPService, HeartbeatMixin
 from .utils.settings import import_settings
 from .utils.devices import generate_device_name
 from .utils.messages import send_emqp_message as sendmsg
+from .utils.functions import get_timeout_from_headers
 from . import worker
 from eventmq.log import setup_logger
 from multiprocessing import Pool
@@ -173,9 +174,11 @@ class JobManager(HeartbeatMixin, EMQPService):
         else:
             callback = self.worker_done
 
+        timeout = get_timeout_from_headers(headers)
+
         # kick off the job asynchronously with an appropiate callback
         self.workers.apply_async(func=worker.run,
-                                 args=(params, msgid),
+                                 args=(params, msgid, timeout),
                                  callback=callback)
 
     def worker_done_with_reply(self, msgid):

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -444,6 +444,8 @@ class Router(HeartbeatMixin):
             # TODO: Don't discard the message
             return
 
+        self.job_latencies[msgid] = (monotonic(), queue_name)
+
         try:
             worker_addr = self.get_available_worker(queue_name=queue_name)
         except exceptions.NoAvailableWorkerSlotsError:

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -51,6 +51,8 @@ class Scheduler(HeartbeatMixin, EMQPService):
     SERVICE_TYPE = constants.CLIENT_TYPE.scheduler
 
     def __init__(self, *args, **kwargs):
+        self.name = kwargs.get('name', None)
+
         logger.info('Initializing Scheduler...')
         import_settings()
         super(Scheduler, self).__init__(*args, **kwargs)

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -415,7 +415,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
 
     def get_run_count_from_headers(self, headers):
         run_count = INFINITE_RUN_COUNT
-        for header in headers:
+        for header in headers.split(','):
             if 'run_count:' in header:
                 run_count = int(header.split(':')[1])
         return run_count

--- a/eventmq/tests/test_client_messages.py
+++ b/eventmq/tests/test_client_messages.py
@@ -56,6 +56,7 @@ class TestCase(unittest.TestCase):
                                    reply_requested=True,
                                    guarantee=False,
                                    retry_count=3,
+                                   timeout=0,
                                    queue='test_queue')
         # defer_job should return _msgid untouched
         self.assertEqual(msgid, _msgid)
@@ -73,6 +74,7 @@ class TestCase(unittest.TestCase):
                                        reply_requested=True,
                                        guarantee=False,
                                        retry_count=3,
+                                       timeout=0,
                                        queue='test_queue')
 
         with LogCapture() as log_checker:

--- a/eventmq/tests/test_client_messages.py
+++ b/eventmq/tests/test_client_messages.py
@@ -258,6 +258,29 @@ class TestCase(unittest.TestCase):
              messages.serialize(msg)))
 
     @mock.patch('eventmq.client.messages.send_emqp_message')
+    def test_send_request_all_headers(self, snd_empq_msg_mock):
+        _msgid = '0svny2rj8d0-aofinsud4839'
+        snd_empq_msg_mock.return_value = _msgid
+
+        socket = mock.Mock()
+
+        msg = {'alksjfd': [1, 2],
+               'laksdjf': 4,
+               'alkfjds': 'alksdjf'}
+
+        msgid = messages.send_request(socket, msg,
+                                      reply_requested=True,
+                                      guarantee=True,
+                                      retry_count=2,
+                                      timeout=3)
+        self.assertEqual(msgid, _msgid)
+        snd_empq_msg_mock.assert_called_with(
+            socket, 'REQUEST',
+            ('default',
+             'reply-requested,guarantee,retry-count:2,timeout:3',
+             messages.serialize(msg)))
+
+    @mock.patch('eventmq.client.messages.send_emqp_message')
     def test_send_schedule_request(self, snd_empq_msg_mock):
         _msgid = 'va08n45-lanf548afn984-m7489vs'
         snd_empq_msg_mock.return_value = _msgid

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -84,6 +84,21 @@ class TestCase(unittest.TestCase):
             callback=jm.worker_done,
             func=run_mock)
 
+    @mock.patch('eventmq.jobmanager.worker.run')
+    @mock.patch('multiprocessing.pool.Pool.apply_async')
+    def test_on_request_with_timeout(self, apply_async_mock, run_mock):
+        timeout = 3
+        _msgid = 'aaa0j8-ac40jf0-04tjv'
+        _msg = ['a', 'timeout:{}'.format(timeout), '["run", {"a": 1}]']
+
+        jm = jobmanager.JobManager()
+
+        jm.on_request(_msgid, _msg)
+        apply_async_mock.assert_called_with(
+            args=({'a': 1}, _msgid, timeout),
+            callback=jm.worker_done,
+            func=run_mock)
+
     @mock.patch('eventmq.jobmanager.sendmsg')
     @mock.patch('zmq.Socket.unbind')
     def test_on_disconnect(self, socket_mock, sendmsg_mock):

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -80,7 +80,7 @@ class TestCase(unittest.TestCase):
 
         jm.on_request(_msgid, _msg)
         apply_async_mock.assert_called_with(
-            args=({'a': 1}, _msgid),
+            args=({'a': 1}, _msgid, None),
             callback=jm.worker_done,
             func=run_mock)
 

--- a/eventmq/tests/test_scheduler.py
+++ b/eventmq/tests/test_scheduler.py
@@ -1,0 +1,38 @@
+# This file is part of eventmq.
+#
+# eventmq is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# eventmq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with eventmq.  If not, see <http://www.gnu.org/licenses/>.
+import time
+import unittest
+
+import mock
+
+from .. import conf, constants, scheduler
+
+ADDR = 'inproc://pour_the_rice_in_the_thing'
+
+
+class TestCase(unittest.TestCase):
+    def test__setup(self):
+        sched = scheduler.Scheduler(name='RuckusBringer')
+        self.assertEqual(sched.name, 'RuckusBringer')
+
+        self.assertFalse(sched.awaiting_startup_ack)
+        self.assertEqual(sched.status, constants.STATUS.ready)
+
+# EMQP Tests
+    def test_reset(self):
+        sched = scheduler.Scheduler()
+
+        self.assertFalse(sched.awaiting_startup_ack)
+        self.assertEqual(sched.status, constants.STATUS.ready)

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -212,7 +212,7 @@ def get_timeout_from_headers(headers):
         timeout(int): The timeout if found, else None
     """
     timeout = None
-    for header in headers:
+    for header in headers.split(','):
         if 'timeout:' in header:
             timeout = int(header.split(':')[1])
     return timeout

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -205,7 +205,7 @@ def callable_from_name(callable_name, *args, **kwargs):
     return callable_
 
 
-def get_timeout_from_headers(self, headers):
+def get_timeout_from_headers(headers):
     """Return the timeout value if it exists in the given headers
 
     Retruns:

--- a/eventmq/utils/functions.py
+++ b/eventmq/utils/functions.py
@@ -203,3 +203,16 @@ def callable_from_name(callable_name, *args, **kwargs):
         raise CallableFromPathError(str(e))
 
     return callable_
+
+
+def get_timeout_from_headers(self, headers):
+    """Return the timeout value if it exists in the given headers
+
+    Retruns:
+        timeout(int): The timeout if found, else None
+    """
+    timeout = None
+    for header in headers:
+        if 'timeout:' in header:
+            timeout = int(header.split(':')[1])
+    return timeout


### PR DESCRIPTION
Adds timeout support, defaulting to 0 (infinite)
You can now add a timeout parameter to defer_job

This should help with slot leakage problems - i.e. processes never timing out and consuming a slot indefenitely

I also added a few tests to increase coverage, as well as test the timeout header parsing - currently there aren't any tests for the worker pool code.
