### PR TITLE
Update the queue prioritizer to use key instead of cmp

### DIFF
--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -33,7 +33,7 @@ from .utils.messages import (
     fwd_emqp_router_message as fwdmsg,
     parse_router_message
 )
-from .utils import tuplify, zero_index_cmp
+from .utils import tuplify
 from .utils.settings import import_settings
 from .utils.devices import generate_device_name
 from .utils.timeutils import monotonic, timestamp
@@ -853,7 +853,7 @@ class Router(HeartbeatMixin):
         Returns:
             decsending order list. E.g. ((20, 'a'), (14, 'b'), (12, 'c'))
         """
-        return sorted(unprioritized_iterable, cmp=zero_index_cmp, reverse=True)
+        return sorted(unprioritized_iterable, key=lambda x: x[0], reverse=True)
 
     def get_status(self):
         """

--- a/eventmq/utils/__init__.py
+++ b/eventmq/utils/__init__.py
@@ -40,14 +40,6 @@ def random_characters():
     return str(uuid.uuid4())
 
 
-def zero_index_cmp(a, b):
-    """
-    same as ``cmp`` but using the 0-index in a list as the compare value. Used
-    when sorting the values in :attr:`router.Router.queues`.
-    """
-    return cmp(a[0], b[0])
-
-
 def tuplify(v):
     """
     Recursively convert lists to tuples.


### PR DESCRIPTION
This is a python3 fix, but it's also an optimization. 

Tests for that function still pass. :heart: