### PR TITLE
Need to import basestring from past for it to work in python3

### DIFF
--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -174,7 +174,7 @@ def defer_job(
             logger.error('Invalid callable string passed, '
                          'absolute path required: "{}"'.format(func))
             return
-        path, callable_name = split_callable_name(callable_name)
+        path, callable_name = split_callable_name(func)
     elif callable(func):
         callable_name = name_from_callable(func)
         path, callable_name = split_callable_name(callable_name)

--- a/eventmq/client/messages.py
+++ b/eventmq/client/messages.py
@@ -18,6 +18,7 @@
 """
 import logging
 from json import dumps as serialize
+from past.builtins import basestring
 
 from .. import conf
 from ..utils.messages import send_emqp_message


### PR DESCRIPTION
This appears to be the only thing preventing `defer_job` from working in python3.

Also fixes an error that caused `callable_name` to be `None` if passing a string callable.  