### PR TITLE
MAN-1764 - Don't ignore messages when there isn't a valid queue

### DIFF
--- a/eventmq/tests/test_router.py
+++ b/eventmq/tests/test_router.py
@@ -331,7 +331,7 @@ class TestCase(unittest.TestCase):
         client_id = 'c1'
         msgid = 'msg18'
         queue = 'default'
-        msg = [queue, 'hello world']
+        msg = ['red socks', 'hello world']
         worker_id = 'w1'
 
         get_worker_mock.return_value = worker_id

--- a/requirements_.txt
+++ b/requirements_.txt
@@ -4,6 +4,7 @@ monotonic==0.4    # A clock who's time is not changed. used for scheduling
 croniter==0.3.10
 redis==2.10.3
 future==0.15.2
+psutil==5.0.0
 
 # Documentation
 sphinxcontrib-napoleon==0.4.3


### PR DESCRIPTION
**What**
- Assign messages with invalid queue to the default queue
- Limit the default queue to be 75% of total system memory

**Why**
- Don't want to drop messages with invalid queue
- Default queue needs to be larger since it will have more messages in theory

**Testing**
- Adjusted `test_on_request` to have an invalid queue

**Notes**
- This includes a dependency on the `psutil` package