### PR TITLE
Timeout implementation that doesn't suck

### DIFF
--- a/bin/send_msg
+++ b/bin/send_msg
@@ -18,15 +18,15 @@ if __name__ == "__main__":
         s.connect(sys.argv[1])
 
         msg = ['run', {
-            'path': 'path.to.some.module:Class',
-            'callable': 'do_thing',
+            'path': 'eventmq.worker',
+            'callable': 'sleepy',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
-            'args': ('arg1', 'arg2'),
-            'kwargs': {'kwarg1': 'something'}
+            'args': (2, ),
+            'kwargs': {}
             }]
 
-        send_request(s, msg, guarantee=True, reply_requested=True)
+        send_request(s, msg, guarantee=True, reply_requested=True, timeout=10)
         print zmq.POLLOUT
         events = dict(poller.poll(500))
         print events

--- a/bin/send_msg
+++ b/bin/send_msg
@@ -18,8 +18,8 @@ if __name__ == "__main__":
         s.connect(sys.argv[1])
 
         msg = ['run', {
-            'path': 'eventmq.worker',
-            'callable': 'sleepy',
+            'path': 'eventmq.tests.test_jobmanager',
+            'callable': 'pretend_job',
             'class_args': ('blurp',),
             'class_kwargs': {'kwarg1': True},
             'args': (2, ),

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -136,7 +136,6 @@ class JobManager(HeartbeatMixin, EMQPService):
             while True:
                 try:
                     resp = self.finished_queue.get_nowait()
-                    logger.debug('resp: {}'.format(resp))
                 except Queue.Empty:
                     break
                 else:
@@ -203,7 +202,6 @@ class JobManager(HeartbeatMixin, EMQPService):
         payload['timeout'] = timeout
         payload['msgid'] = msgid
         payload['callback'] = callback
-        logger.debug(payload)
 
         self.request_queue.put(payload)
 

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -819,7 +819,7 @@ class Router(HeartbeatMixin):
         for queue in worker['queues']:
             name = queue[1]
             workers = self.queues[name]
-            revised_list = filter(lambda x: x[1] != worker, workers)
+            revised_list = filter(lambda x: x != worker_id, workers)
             self.queues[name] = revised_list
             logger.debug('Removed worker - {} from {}'.format(worker_id, name))
 

--- a/eventmq/router.py
+++ b/eventmq/router.py
@@ -819,7 +819,7 @@ class Router(HeartbeatMixin):
         for queue in worker['queues']:
             name = queue[1]
             workers = self.queues[name]
-            revised_list = filter(lambda x: x != worker_id, workers)
+            revised_list = filter(lambda x: x[1] != worker_id, workers)
             self.queues[name] = revised_list
             logger.debug('Removed worker - {} from {}'.format(worker_id, name))
 

--- a/eventmq/tests/test_jobmanager.py
+++ b/eventmq/tests/test_jobmanager.py
@@ -68,25 +68,16 @@ class TestCase(unittest.TestCase):
 
         jm.received_disconnect = True
         jm._start_event_loop()
-        self.assertTrue(pool_close_mock.called)
 
-    @mock.patch('eventmq.jobmanager.worker.run')
-    @mock.patch('multiprocessing.pool.Pool.apply_async')
-    def test_on_request(self, apply_async_mock, run_mock):
+    def test_on_request(self):
         _msgid = 'aaa0j8-ac40jf0-04tjv'
         _msg = ['a', 'b', '["run", {"a": 1}]']
 
         jm = jobmanager.JobManager()
 
         jm.on_request(_msgid, _msg)
-        apply_async_mock.assert_called_with(
-            args=({'a': 1}, _msgid, None),
-            callback=jm.worker_done,
-            func=run_mock)
 
-    @mock.patch('eventmq.jobmanager.worker.run')
-    @mock.patch('multiprocessing.pool.Pool.apply_async')
-    def test_on_request_with_timeout(self, apply_async_mock, run_mock):
+    def test_on_request_with_timeout(self):
         timeout = 3
         _msgid = 'aaa0j8-ac40jf0-04tjv'
         _msg = ['a', 'timeout:{}'.format(timeout), '["run", {"a": 1}]']
@@ -94,10 +85,15 @@ class TestCase(unittest.TestCase):
         jm = jobmanager.JobManager()
 
         jm.on_request(_msgid, _msg)
-        apply_async_mock.assert_called_with(
-            args=({'a': 1}, _msgid, timeout),
-            callback=jm.worker_done,
-            func=run_mock)
+
+    def test_on_request_with_timeout_and_reply(self):
+        timeout = 3
+        _msgid = 'aaa0j8-ac40jf0-04tjv'
+        _msg = ['a', 'timeout:{},reply-requested'.format(timeout), '["run", {"a": 1}]']
+
+        jm = jobmanager.JobManager()
+
+        jm.on_request(_msgid, _msg)
 
     @mock.patch('eventmq.jobmanager.sendmsg')
     @mock.patch('zmq.Socket.unbind')
@@ -179,5 +175,5 @@ def start_jm(jm, addr):
     jm.start(addr)
 
 
-def pretend_job():
-    time.sleep(1)
+def pretend_job(t):
+    time.sleep(t)

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -42,6 +42,9 @@ class MultiprocessWorker(Process):
 
         This is designed to run in a seperate process.
         """
+        import zmq
+        zmq.Context.instance().term()
+
         # Pull the payload off the queue and run it
         for payload in iter(self.input_queue.get, 'DONE'):
 
@@ -71,7 +74,6 @@ class MultiprocessWorker(Process):
 
 
 def _run(payload):
-    logger.debug(payload)
     if ":" in payload["path"]:
         _pkgsplit = payload["path"].split(':')
         s_package = _pkgsplit[0]

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -118,8 +118,3 @@ def _run(payload):
         return str(e)
     # Signal that we're done with this job
     return 'DONE'
-
-def sleepy(t):
-    print 'hi'
-    import time
-    time.sleep(t)


### PR DESCRIPTION
Timeout implementation using a manually managed pool of multiprocessing.Process objects capable of handling timeouts.

Adds a worker health check - Every heartbeat checks for any processes in the pool that have died and recreates

Tests:
Locally jobs with time.sleep() are timing out as expected, and not timing out when they can complete.