### PR TITLE
EventMQ 0.3rc5 (We'll get 0.3 someday) Fix critical worker health check bug, Simplify scheduler run_count header (remove support for persistance)

### DIFF
--- a/bin/send_request
+++ b/bin/send_request
@@ -21,4 +21,5 @@ if __name__ == "__main__":
            'kwargs': {}
            }]
 
-    send_request(s, msg, guarantee=True, reply_requested=True)
+    while True:
+        send_request(s, msg, guarantee=True, reply_requested=True)

--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3-rc4'
+__version__ = '0.3-rc5'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/conf.py
+++ b/eventmq/conf.py
@@ -86,4 +86,6 @@ RQ_PORT = 6379
 RQ_DB = 0
 RQ_PASSWORD = ''
 
+MAX_JOB_COUNT=1024
+
 # }}}

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -244,13 +244,14 @@ class JobManager(HeartbeatMixin, EMQPService):
 
     def check_worker_health(self):
         """
-        Checks for any dead processes in the pool and recreates them if necessary
+        Checks for any dead processes in the pool and recreates them if
+        necessary
         """
         self._workers = [w for w in self._workers if w.is_alive()]
 
         if len(self._workers) < conf.CONCURRENT_JOBS:
-            logger.warning("{} worker process(es) may have died...recreating")\
-                  .format(conf.CONCURRENT_JOBS - len(self._workers))
+            logger.warning("{} worker process(es) may have died...recreating"
+                           .format(conf.CONCURRENT_JOBS - len(self._workers)))
 
         for i in range(0, conf.CONCURRENT_JOBS - len(self._workers)):
             w = Worker(self.request_queue, self.finished_queue)

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -180,7 +180,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
 
                     logger.debug("Time is: %s; Schedule is: %s - Running %s"
                                  % (ts_now, v[0], msg))
-                    logger.debug("run_count:%s" % v[4])
+
                     if v[4] != INFINITE_RUN_COUNT:
                         # If run_count was 0, we cancel the job
                         if v[4] <= 0:

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -304,6 +304,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
         # in memory
         try:
             if (self.redis_server.get(schedule_hash)):
+                self.redis_server.delete(schedule_hash)
                 self.redis_server.lrem('interval_jobs', 0, schedule_hash)
                 self.redis_server.save()
         except redis.ConnectionError:

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -180,51 +180,32 @@ class Scheduler(HeartbeatMixin, EMQPService):
 
                     logger.debug("Time is: %s; Schedule is: %s - Running %s"
                                  % (ts_now, v[0], msg))
-
+                    logger.debug("run_count:%s" % v[4])
                     if v[4] != INFINITE_RUN_COUNT:
-                        # Decrement run_count
-                        v[4] -= 1
                         # If run_count was 0, we cancel the job
                         if v[4] <= 0:
                             cancel_jobs.append(k)
-                        # Otherwise we run the job
                         else:
-                            # Send job and update next schedule time
+                            # Decrement run_count
+                            v[4] -= 1
                             self.send_request(msg, queue=queue)
                             v[0] = next(v[2])
-                            # Rename redis key and save new run_count counter
-                            try:
-                                self.redis_server.rename(k,
-                                                         self.schedule_hash(v))
-                                self.redis_server.set(self.schedule_hash(v),
-                                                      serialize(v))
-                                self.redis_server.save()
-                            except redis.ConnectionError:
-                                logger.warning("Couldn't contact redis server")
-                            except Exception as e:
-                                logger.warning(
-                                    'Unable to update key in redis '
-                                    'server: {}'.format(e.message))
                     else:
                         # Scheduled job is in running infinitely
                         # Send job and update next schedule time
                         self.send_request(msg, queue=queue)
                         v[0] = next(v[2])
-                        # Persist changes to redis
-                        try:
-                            self.redis_server.set(
-                                self.schedule_hash(v), serialize(v))
-                            self.redis_server.save()
-                        except redis.ConnectionError:
-                            logger.warning("Couldn't contact redis server")
-                        except Exception as e:
-                            logger.warning(
-                                'Unable to update key in redis '
-                                'server: {}'.format(e.message))
 
             for job in cancel_jobs:
-                message = self.interval_jobs[k][1]
-                self.unschedule_job(message)
+                try:
+                    logger.debug('Cancelling job due to run_count: {}'
+                                 .format(k))
+                    self.redis_server.delete(k)
+                    self.redis_server.lrem('interval_jobs', 0, k)
+                except Exception as e:
+                    logger.warning(
+                        'Unable to update key in redis '
+                        'server: {}'.format(e))
                 del self.interval_jobs[k]
 
             if not self.maybe_send_heartbeat(events):
@@ -244,7 +225,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
 
             except Exception as e:
                 logger.warning('Unable to connect to redis server: {}'.format(
-                    e.message))
+                    e))
         else:
             return self._redis_server
 
@@ -358,6 +339,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
         headers = message[1]
         interval = int(message[2])
         cron = str(message[4])
+        run_count = self.get_run_count_from_headers(headers)
 
         schedule_hash = self.schedule_hash(message)
 
@@ -379,7 +361,7 @@ class Scheduler(HeartbeatMixin, EMQPService):
                 message[3],
                 inter_iter,
                 queue,
-                self.get_run_count_from_headers(headers)
+                run_count
             ]
 
             if schedule_hash in self.cron_jobs:
@@ -413,8 +395,12 @@ class Scheduler(HeartbeatMixin, EMQPService):
         except Exception as e:
             logger.warning(str(e))
 
+        # Send a request in haste mode, decrement run_count if valid
         if 'nohaste' not in headers:
-            self.send_request(message[3], queue=queue)
+            # Don't allow decrement past 0
+            if run_count > 0:
+                self.interval_jobs[schedule_hash][4] -= 1
+                self.send_request(message[3], queue=queue)
 
     def get_run_count_from_headers(self, headers):
         run_count = INFINITE_RUN_COUNT

--- a/eventmq/worker.py
+++ b/eventmq/worker.py
@@ -20,15 +20,12 @@ Defines different short-lived workers that execute jobs
 from importlib import import_module
 from multiprocessing import Process
 from threading import Thread
+from . import conf
 
 import logging
 import os
 
 logger = logging.getLogger(__name__)
-
-
-# Force reset after running a certain number of jobs
-MAX_JOB_COUNT = 1024
 
 
 class MultiprocessWorker(Process):
@@ -80,7 +77,7 @@ class MultiprocessWorker(Process):
             resp['callback'] = payload['callback']
             self.output_queue.put(resp)
 
-            if self.job_count > MAX_JOB_COUNT:
+            if self.job_count > conf.MAX_JOB_COUNT:
                 break
 
         logger.debug("Worker death, PID: {}".format(os.getpid()))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eventmq',
-    version='0.3-rc4',
+    version='0.3-rc5',
     description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
Also fixes edge cases for run_count to interact properly with nohaste header:

run_count will now always cause the number of requests specified if greather than or equal to 0:

For example:

1) headers=(nohaste, run_count:1)
2) headers=(run_count:1)

will both issue 1 request exactly, but example 1 will issue it 'interval_secs' in the future, where as example 2 will issue it immediately (default behavior) 

Also adds support for `run_count:0` which will issue exactly 0 requests.
Also fixes a critical bug in logging the fact we are recreating a process in the worker health check
Implements a MAX_JOB_COUNT to prevent memory creep

Tests:

Running ~20k jobs through and examining the processes I got 4 normal running sub-processes that went defunct as they hit 1k (default MAX_JOB_COUNT), and 2 seconds later or so they revived:

```david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 50 15:07 pts/8    00:00:24 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4732  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4733  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4734  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4735  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4749  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo
david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 51 15:07 pts/8    00:00:25 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4732  4612  3 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4733  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4734  4612  3 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4735  4612  3 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4751  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo
david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 50 15:07 pts/8    00:00:25 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4732  4612  3 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4733  4612  3 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4734  4612  3 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4735  4612  3 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4753  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo
david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 49 15:07 pts/8    00:00:25 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4732  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4733  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4734  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4735  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4755  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo
david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 49 15:07 pts/8    00:00:25 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4732  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4733  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4734  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4735  4612  2 15:08 pts/8    00:00:00 [emq-jobmanager] <defunct>
david     4757  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo
david@kaibuntu:~/work/eventmq/bin$ ps -ef | grep emq-jo
david     4612 10763 49 15:07 pts/8    00:00:26 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4758  4612  2 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4759  4612  3 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4760  4612  2 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4761  4612  4 15:08 pts/8    00:00:00 /usr/bin/python /usr/local/bin/emq-jobmanager
david     4767  2266  0 15:08 pts/11   00:00:00 grep --color=auto emq-jo```
