### PR TITLE
ZMQError is thrown when we are polling and its rudely interrupted, ha…

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3-rc7'
+__version__ = '0.3-rc8'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eventmq',
-    version='0.3-rc7',
+    version='0.3-rc8',
     description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
…ndle it

There are cases a supervising process can interrupt syscalls while we are polling for ZMQ events.  This catches those and treats it as a disconnect so we can shutdown gracefully as opposed to leaving orphan processes.