### PR TITLE
Scheduled jobs to send reply-requested header

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3-rc9'
+__version__ = '0.3-rc10'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/eventmq/jobmanager.py
+++ b/eventmq/jobmanager.py
@@ -132,6 +132,10 @@ class JobManager(HeartbeatMixin, EMQPService):
                     self.request_queue.put_nowait('DONE')
                 self.request_queue.close()
                 self.request_queue.join_thread()
+
+                for w in self.workers:
+                    w.join()
+
                 break
 
             try:

--- a/eventmq/scheduler.py
+++ b/eventmq/scheduler.py
@@ -242,7 +242,8 @@ class Scheduler(HeartbeatMixin, EMQPService):
             str: ID of the message
         """
         jobmsg = json.loads(jobmsg)
-        msgid = send_request(self.outgoing, jobmsg, queue=queue)
+        msgid = send_request(self.outgoing, jobmsg, queue=queue,
+                             reply_requested=True)
 
         return msgid
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='eventmq',
-    version='0.3-rc9',
+    version='0.3-rc10',
     description='EventMQ messaging system based on ZeroMQ',
     packages=find_packages(),
     install_requires=['pyzmq==15.4.0',


### PR DESCRIPTION
What:

Scheduled jobs don't send any headers right now - this forces the reply-requested header so we can track how long they take - we should in the future discuss what, if any headers get transferred from the original SCHEDULE message.

Also this does a join on every worker when a disconnect and shutdown occurs.  This helps prevent orphans.

Why:
There are 120k entries in the job_latencies dictionary on the broker - assumedly all from this.  If we get rid of this source we can easily see what our dropped message rate is (hopefully 0)