### PR TITLE
TE-36287: Python & Django upgrade - Upgrade packages to make eventmq-worker container working on Eventboard

### DIFF
--- a/eventmq/__init__.py
+++ b/eventmq/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'EventMQ Contributors'
-__version__ = '0.3.13'
+__version__ = '0.3.14'
 
 PROTOCOL_VERSION = 'eMQP/1.0'
 

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
         'pyzmq==18.1.0',
         'six>=1.14,<2',
         'monotonic==0.4',
-        'croniter==0.3.10',
-        'future==0.15.2',
-        'psutil==5.6.6',
+        'croniter==1.0.5',
+        'future==0.18.3',
+        'psutil==5.6.7',
     ],
     extras_require={
           'docs': ['Sphinx==1.5.2', ],


### PR DESCRIPTION
What?
Upgrade packages to make eventmq-worker container working on Eventboard.

Why?
Due to mismatch versions of psutil, future and croniter, we were getting pkg_resources.ContextualVersionConflict and pkg_resources.DistributionNotFound errors while making eventmq-worker container up on Eventboard.

Jira Ticket(s):
https://eptura.atlassian.net/browse/TE-36287